### PR TITLE
Added Hackney Shared Asset package to project (

### DIFF
--- a/RepairsListener/RepairsListener.csproj
+++ b/RepairsListener/RepairsListener.csproj
@@ -19,8 +19,9 @@
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.0.0" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
-    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
+    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.79.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.37.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
RepairsListener, line 25, errors when it receives an object of type Asset

**RepairsListener** - message is of type **Asset**
![image](https://github.com/LBHackney-IT/asset-information-api/assets/70756861/72d9d673-a98b-4b8e-ac32-f4f4808ab1cc)

**Error**
![image](https://github.com/LBHackney-IT/asset-information-api/assets/70756861/2add5a49-6b4f-4022-a395-5406f551319d)

The project currently has no references to `Hackney.Shared.Asset`. This PR updates `Hackney.Core.DynamoDb` (required by `Hackney.Shared.Asset`)  and adds Hackney.Shared.Asset to the project, which should resolve the "unable to cast" error.