### PR TITLE
Fix build error - Added null logger to test instance of CreateAssetUs…

### DIFF
--- a/RepairsListener.Tests/UseCase/CreateAssetUseCaseTests.cs
+++ b/RepairsListener.Tests/UseCase/CreateAssetUseCaseTests.cs
@@ -1,6 +1,7 @@
 using AutoFixture;
 using FluentAssertions;
 using Hackney.Shared.Asset.Domain;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualBasic;
 using Moq;
 using RepairsListener.Boundary;
@@ -25,7 +26,7 @@ namespace RepairsListener.Tests.UseCase
         {
             _gatewayMock = new Mock<IRepairsStoredProcedureGateway>();
 
-            _classUnderTest = new CreateAssetUseCase(_gatewayMock.Object);
+            _classUnderTest = new CreateAssetUseCase(_gatewayMock.Object, new NullLogger<CreateAssetUseCase>());
         }
 
         [Fact]


### PR DESCRIPTION
Fix build error - Added null logger to test instance of CreateAssetUseCase

Failed build: https://app.circleci.com/pipelines/github/LBHackney-IT/repairs-listener/45/workflows/51c483e3-8ed6-42d6-a3cf-2f066498357d/jobs/159