### PR TITLE
MR-516 - Added more logging

### DIFF
--- a/RepairsListener/UseCase/CreateAssetUseCase.cs
+++ b/RepairsListener/UseCase/CreateAssetUseCase.cs
@@ -5,8 +5,8 @@ using Hackney.Core.Logging;
 using System;
 using System.Threading.Tasks;
 using Hackney.Shared.Asset.Domain;
-using Newtonsoft.Json;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 namespace RepairsListener.UseCase
 {
@@ -27,13 +27,13 @@ namespace RepairsListener.UseCase
         {
             if (message is null) throw new ArgumentNullException(nameof(message));
 
-            string jsonSnsMessage = JsonConvert.SerializeObject(message);
+            string jsonSnsMessage = JsonSerializer.Serialize(message);
             _logger.LogInformation("RepairsListener received SNS message with body {JsonSnsMessage}", jsonSnsMessage);
 
             string newDataRawText = message.EventData.NewData.ToString();
             _logger.LogInformation("For troubleshooting purposes: NewData raw text from SNS message: {NewDataRawText}", newDataRawText);
 
-            string newDataJson = JsonConvert.SerializeObject(message.EventData.NewData);
+            string newDataJson = JsonSerializer.Serialize(message.EventData.NewData);
             _logger.LogInformation("For troubleshooting purposes: NewData JSON from SNS message: {NewDataJson}", newDataJson);
 
             var newData = (Asset) message.EventData.NewData;

--- a/RepairsListener/UseCase/CreateAssetUseCase.cs
+++ b/RepairsListener/UseCase/CreateAssetUseCase.cs
@@ -30,6 +30,11 @@ namespace RepairsListener.UseCase
             string jsonSnsMessage = JsonConvert.SerializeObject(message);
             _logger.LogInformation("RepairsListener received SNS message with body {JsonSnsMessage}", jsonSnsMessage);
 
+            string newDataRawText = message.EventData.NewData.ToString();
+            _logger.LogInformation("For troubleshooting purposes: NewData raw text from SNS message: {NewDataRawText}", newDataRawText);
+
+            string newDataJson = JsonConvert.SerializeObject(message.EventData.NewData);
+            _logger.LogInformation("For troubleshooting purposes: NewData JSON from SNS message: {NewDataJson}", newDataJson);
 
             var newData = (Asset) message.EventData.NewData;
             var propertyReference = newData.AssetId;


### PR DESCRIPTION
- Added additional logging for troubleshooting purposes
- Changed from Newtonsoft.Json to System.Text.Json for converting JSON

Asset API sends the correct "payload" (Asset obj) when the SNS message is published to the relevant queue.
![image](https://github.com/LBHackney-IT/repairs-listener/assets/70756861/d54db269-d9e8-49ab-9356-6a6ea3447996)

RepairsListener's previously implemented log shows an unexpected  `ValueKind: 1` value for NewData. Looking online, this ValueKind seems to be potentially related to `System.Text.Json` (https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonelement.valuekind?view=net-7.0)
![image](https://github.com/LBHackney-IT/repairs-listener/assets/70756861/8e0fa934-23ff-4ec0-9974-d2240b8c75ad)
