### PR TITLE
MR-516 - Add JsonSerializerOptions and fix logging

### DIFF
--- a/RepairsListener/UseCase/CreateAssetUseCase.cs
+++ b/RepairsListener/UseCase/CreateAssetUseCase.cs
@@ -33,9 +33,14 @@ namespace RepairsListener.UseCase
             // Get asset data from SNS message
             string newAssetStringified = message.EventData.NewData.ToString();
 
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+
             // Deserialize the JSON content directly into an Asset object
-            Asset newAsset = JsonSerializer.Deserialize<Asset>(newAssetStringified);
-            _logger.LogInformation("New Asset received by RepairsListener. Asset: {NewAssetStringified}", newAsset);
+            Asset newAsset = JsonSerializer.Deserialize<Asset>(newAssetStringified, options);
+            _logger.LogInformation("New Asset received by RepairsListener. Asset: {NewAsset}", JsonSerializer.Serialize(newAsset));
 
             var propertyReference = newAsset.AssetId;
 


### PR DESCRIPTION
The SNS "new asset created" message is now received  by this listener and the Asset object is somehow assembled, however the code throws ArgumentNullException (line 44 in screenshot) despite an `assetId` being there.

![image](https://github.com/LBHackney-IT/repairs-listener/assets/70756861/cce13230-3a7c-4ef6-88fd-95d4b8321d0b)

Looking at Cloudwatch, we see an `assetId`, which leads me to think there may be an issue with the capitalization of the properties.

- Added `JsonSerializerOptions` with `PropertyNameCaseInsensitive = true` so that when the `Asset` object is created, properties are matched regardless of case. Not sure, but this might be the reason why the exception is thrown. There is an `assetId` but the code is checking for `AssetId`.

- Fixed log so that we can see what newAsset looks like in Cloudwatch (did not set up this log correctly in previous PR)