### PR TITLE
MR-516 - Updated VPC config in serverless file

### DIFF
--- a/RepairsListener/serverless.yml
+++ b/RepairsListener/serverless.yml
@@ -31,8 +31,8 @@ functions:
     events:
       ### Specify the parameter containing the queue arn used to trigget the lambda function here
       ### This will have been defined in the terraform configuration
-       - sqs: ${ssm:/sqs-queue/${self:provider.stage}/repairshubinbound/arn} 
-      
+       - sqs: ${ssm:/sqs-queue/${self:provider.stage}/repairshubinbound/arn}
+
 resources:
   Resources:
     lambdaExecutionRole:
@@ -51,7 +51,7 @@ resources:
         ManagedPolicyArns:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
           - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
-        Policies:          
+        Policies:
           - PolicyName: manageLogs
             PolicyDocument:
               Version: '2012-10-17'
@@ -104,14 +104,20 @@ resources:
 custom:
   vpc:
     development:
+      securityGroupIds:
+        - sg-08e28776da7918e4b
       subnetIds:
-        - subnet-0deabb5d8fb9c3446
-        - subnet-000b89c249f12a8ad
+        - subnet-0140d06fb84fdb547
+        - subnet-05ce390ba88c42bfd
     staging:
+      securityGroupIds:
+        - sg-011122be56aa0af9e
       subnetIds:
         - subnet-06d3de1bd9181b0d7
         - subnet-0ed7d7713d1127656
     production:
+      securityGroupIds:
+        - sg-0ec487b8798809285
       subnetIds:
-        - subnet-01d3657f97a243261
-        - subnet-0b7b8fea07efabf34
+        - subnet-0beb266003a56ca82
+        - subnet-06a697d86a9b6ed01


### PR DESCRIPTION
From the Cloudwatch logs we've identified a timeout. This happens at the same time when RepairsListener is supposed to open a connection with the RDS database, but it seems to fail.

![image](https://github.com/LBHackney-IT/repairs-listener/assets/70756861/c62f0615-6b6e-4044-a0b1-14770a438c45)

Looking at the subnets in the serverless file, they seem to be different compared to the subnets in the serverless file of RepairsAPI, which are also the same as the Repairs database.
![image](https://github.com/LBHackney-IT/repairs-listener/assets/70756861/01462b5c-0366-473b-b996-0756d4872f22)


This PR changes the current VPC settings and makes them the same as RepairsAPI