### PR TITLE
Update pipeline / disable staging deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,10 @@
 version: 2.1
 
-# orbs that we will use to build our pipeline
 orbs:
   aws-cli: circleci/aws-cli@5.1.1
   node: circleci/node@6.3.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
-# executors that we will use to run our pipeline
 executors:
   docker-python:
     docker:
@@ -18,14 +16,12 @@ executors:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:8.0
 
-# references that we will use in our pipeline
 references:
   workspace_root: &workspace_root "~"
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-# commands that we will use to build our pipeline
 commands:
   assume-role-and-persist-workspace:
     description: "Assumes deployment role and persists credentials across jobs"
@@ -102,7 +98,6 @@ commands:
             cd ./RepairsListener/
             npx --yes serverless deploy --stage <<parameters.stage>> --conceal
 
-# jobs that we will use to build our pipeline
 jobs:
   check-code-formatting:
     executor: docker-dotnet
@@ -210,20 +205,6 @@ workflows:
               ignore:
                 - develop
                 - master
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          filters:
-            branches:
-              ignore:
-                - develop
-                - master
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          filters:
-            branches:
-              ignore:
-                - develop
-                - master
       - terraform-plan-development:
           requires:
             - assume-role-development
@@ -232,9 +213,27 @@ workflows:
               ignore:
                 - develop
                 - master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          requires:
+            - terraform-plan-development
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
       - terraform-plan-staging:
           requires:
             - assume-role-staging
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+            - terraform-plan-staging
           filters:
             branches:
               ignore:
@@ -277,24 +276,24 @@ workflows:
       - assume-role-staging:
           # context: api-assume-role-housing-staging-context
           context: api-assume-role-staging-context
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - terraform-init-and-apply-to-staging:
           requires:
             - assume-role-staging
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - deploy-to-staging:
           context:
             - "Serverless Framework"
             - api-nuget-token-context
           requires:
             - terraform-init-and-apply-to-staging
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
       - permit-production-terraform-release:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,12 @@
 version: 2.1
 
+# orbs that we will use to build our pipeline
 orbs:
   aws-cli: circleci/aws-cli@5.1.1
   node: circleci/node@6.3.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
+# executors that we will use to run our pipeline
 executors:
   docker-python:
     docker:
@@ -16,12 +18,14 @@ executors:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:8.0
 
+# references that we will use in our pipeline
 references:
   workspace_root: &workspace_root "~"
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
+# commands that we will use to build our pipeline
 commands:
   assume-role-and-persist-workspace:
     description: "Assumes deployment role and persists credentials across jobs"
@@ -38,6 +42,21 @@ commands:
           root: *workspace_root
           paths:
             - .aws
+  terraform-plan:
+    description: "Runs terraform plan"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: plan
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:
@@ -51,7 +70,8 @@ commands:
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
             terraform init
-          name: get and init
+            terraform plan
+          name: get, init and plan
       - run:
           name: apply
           command: |
@@ -82,6 +102,7 @@ commands:
             cd ./RepairsListener/
             npx --yes serverless deploy --stage <<parameters.stage>> --conceal
 
+# jobs that we will use to build our pipeline
 jobs:
   check-code-formatting:
     executor: docker-dotnet
@@ -119,6 +140,21 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
+  terraform-plan-development:
+    executor: docker-terraform
+    steps:
+      - terraform-plan:
+          environment: "development"
+  terraform-plan-staging:
+    executor: docker-terraform
+    steps:
+      - terraform-plan:
+          environment: "staging"
+  terraform-plan-production:
+    executor: docker-terraform
+    steps:
+      - terraform-plan:
+          environment: "production"
   terraform-init-and-apply-to-development:
     executor: docker-terraform
     steps:
@@ -162,6 +198,51 @@ workflows:
                 - master
       - build-and-test:
           context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+      - terraform-plan-development:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+      - terraform-plan-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              ignore:
+                - develop
+                - master
+      - terraform-plan-production:
+          requires:
+            - assume-role-production
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,11 +125,11 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_DEVELOPMENT
-  assume-role-staging:
-    executor: docker-python
-    steps:
-      - assume-role-and-persist-workspace:
-          aws-account: $AWS_ACCOUNT_STAGING
+  # assume-role-staging:
+  #   executor: docker-python
+  #   steps:
+  #     - assume-role-and-persist-workspace:
+  #         aws-account: $AWS_ACCOUNT_STAGING
   assume-role-production:
     executor: docker-python
     steps:
@@ -140,11 +140,11 @@ jobs:
     steps:
       - terraform-plan:
           environment: "development"
-  terraform-plan-staging:
-    executor: docker-terraform
-    steps:
-      - terraform-plan:
-          environment: "staging"
+  # terraform-plan-staging:
+  #   executor: docker-terraform
+  #   steps:
+  #     - terraform-plan:
+  #         environment: "staging"
   terraform-plan-production:
     executor: docker-terraform
     steps:
@@ -155,11 +155,11 @@ jobs:
     steps:
       - terraform-init-then-apply:
           environment: "development"
-  terraform-init-and-apply-to-staging:
-    executor: docker-terraform
-    steps:
-      - terraform-init-then-apply:
-          environment: "staging"
+  # terraform-init-and-apply-to-staging:
+  #   executor: docker-terraform
+  #   steps:
+  #     - terraform-init-then-apply:
+  #         environment: "staging"
   terraform-init-and-apply-to-production:
     executor: docker-terraform
     steps:
@@ -170,11 +170,11 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "development"
-  deploy-to-staging:
-    executor: docker-dotnet
-    steps:
-      - deploy-lambda:
-          stage: "staging"
+  # deploy-to-staging:
+  #   executor: docker-dotnet
+  #   steps:
+  #     - deploy-lambda:
+  #         stage: "staging"
   deploy-to-production:
     executor: docker-dotnet
     steps:
@@ -213,29 +213,28 @@ workflows:
               ignore:
                 - develop
                 - master
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          # context: api-assume-role-staging-context
-          requires:
-            - terraform-plan-development
-          filters:
-            branches:
-              ignore:
-                - develop
-                - master
-      - terraform-plan-staging:
-          requires:
-            - assume-role-staging
-            - terraform-plan-development
-          filters:
-            branches:
-              ignore:
-                - develop
-                - master
+      # - assume-role-staging:
+      #     context: api-assume-role-housing-staging-context
+      #     requires:
+      #       - terraform-plan-development
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - develop
+      #           - master
+      # - terraform-plan-staging:
+      #     requires:
+      #       - assume-role-staging
+      #       - terraform-plan-development
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - develop
+      #           - master
       - assume-role-production:
           context: api-assume-role-housing-production-context
           requires:
-            - terraform-plan-staging
+            - terraform-plan-development
           filters:
             branches:
               ignore:
@@ -244,7 +243,7 @@ workflows:
       - terraform-plan-production:
           requires:
             - assume-role-production
-            - terraform-plan-staging
+            - terraform-plan-development
           filters:
             branches:
               ignore:
@@ -277,33 +276,33 @@ workflows:
 
   check-and-deploy-staging-and-production:
     jobs:
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          filters:
-            branches:
-              only: master
-      - terraform-init-and-apply-to-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
-      - deploy-to-staging:
-          context:
-            - "Serverless Framework"
-            - api-nuget-token-context
-          requires:
-            - terraform-init-and-apply-to-staging
-          filters:
-            branches:
-              only: master
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: master
+      # - assume-role-staging:
+      #     context: api-assume-role-staging-context
+      #     filters:
+      #       branches:
+      #         only: master
+      # - terraform-init-and-apply-to-staging:
+      #     requires:
+      #       - assume-role-staging
+      #     filters:
+      #       branches:
+      #         only: master
+      # - deploy-to-staging:
+      #     context:
+      #       - "Serverless Framework"
+      #       - api-nuget-token-context
+      #     requires:
+      #       - terraform-init-and-apply-to-staging
+      #     filters:
+      #       branches:
+      #         only: master
+      # - permit-production-terraform-release:
+      #     type: approval
+      #     requires:
+      #       - deploy-to-staging
+      #     filters:
+      #       branches:
+      #         only: master
       - assume-role-production:
           context: api-assume-role-housing-production-context
           requires:
@@ -320,7 +319,7 @@ workflows:
       - permit-production-release:
           type: approval
           requires:
-            - deploy-to-staging
+            # - deploy-to-staging
             - terraform-init-and-apply-to-production
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,6 @@ workflows:
           requires:
             - assume-role-staging
             - terraform-plan-development
-          when: always
           filters:
             branches:
               ignore:
@@ -245,7 +244,6 @@ workflows:
           requires:
             - assume-role-production
             - terraform-plan-staging
-          when: always
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,13 +295,13 @@ workflows:
       #     filters:
       #       branches:
       #         only: master
-      # - permit-production-terraform-release:
-      #     type: approval
-      #     requires:
-      #       - deploy-to-staging
-      #     filters:
-      #       branches:
-      #         only: master
+      - permit-production-terraform-release:
+          type: approval
+          # requires:
+          #   - deploy-to-staging
+          filters:
+            branches:
+              only: master
       - assume-role-production:
           context: api-assume-role-housing-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,6 @@ workflows:
                 - develop
                 - master
 
-
   check-and-deploy-development:
     jobs:
       - assume-role-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,25 +194,26 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          filters:
-            branches:
-              only: master
+          # context: api-assume-role-housing-staging-context
+          context: api-assume-role-staging-context
+          # filters:
+          #   branches:
+          #     only: master
       - terraform-init-and-apply-to-staging:
           requires:
             - assume-role-staging
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - deploy-to-staging:
           context:
             - "Serverless Framework"
             - api-nuget-token-context
           requires:
             - terraform-init-and-apply-to-staging
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - permit-production-terraform-release:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,10 +222,11 @@ workflows:
               ignore:
                 - develop
                 - master
-          when: always
       - terraform-plan-staging:
           requires:
             - assume-role-staging
+            - terraform-plan-development
+          when: always
           filters:
             branches:
               ignore:
@@ -240,15 +241,17 @@ workflows:
               ignore:
                 - develop
                 - master
-          when: always
       - terraform-plan-production:
           requires:
             - assume-role-production
+            - terraform-plan-staging
+          when: always
           filters:
             branches:
               ignore:
                 - develop
                 - master
+
 
   check-and-deploy-development:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,8 @@ workflows:
                 - develop
                 - master
       - assume-role-staging:
-          context: api-assume-role-staging-context
+          context: api-assume-role-housing-staging-context
+          # context: api-assume-role-staging-context
           requires:
             - terraform-plan-development
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ workflows:
               ignore:
                 - develop
                 - master
+          when: always
       - terraform-plan-staging:
           requires:
             - assume-role-staging
@@ -239,6 +240,7 @@ workflows:
               ignore:
                 - develop
                 - master
+          when: always
       - terraform-plan-production:
           requires:
             - assume-role-production
@@ -274,7 +276,6 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       - assume-role-staging:
-          # context: api-assume-role-housing-staging-context
           context: api-assume-role-staging-context
           filters:
             branches:

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,117 +1,117 @@
-# INSTRUCTIONS:
-# 1) ENSURE YOU POPULATE THE LOCALS
-# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES
-# 3) YOUR CODE WOULD NOT COMPILE IF STEP NUMBER 2 IS NOT PERFORMED!
-# 4) ENSURE YOU CREATE A BUCKET FOR YOUR STATE FILE AND YOU ADD THE NAME BELOW - MAINTAINING THE STATE OF THE INFRASTRUCTURE YOU CREATE IS ESSENTIAL - FOR APIS, THE BUCKETS ALREADY EXIST
-# 5) THE VALUES OF THE COMMON COMPONENTS THAT YOU WILL NEED ARE PROVIDED IN THE COMMENTS
-# 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
-# 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
+# # INSTRUCTIONS:
+# # 1) ENSURE YOU POPULATE THE LOCALS
+# # 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES
+# # 3) YOUR CODE WOULD NOT COMPILE IF STEP NUMBER 2 IS NOT PERFORMED!
+# # 4) ENSURE YOU CREATE A BUCKET FOR YOUR STATE FILE AND YOU ADD THE NAME BELOW - MAINTAINING THE STATE OF THE INFRASTRUCTURE YOU CREATE IS ESSENTIAL - FOR APIS, THE BUCKETS ALREADY EXIST
+# # 5) THE VALUES OF THE COMMON COMPONENTS THAT YOU WILL NEED ARE PROVIDED IN THE COMMENTS
+# # 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
+# # 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
 
-terraform {
-    required_providers {
-        aws = {
-            source  = "hashicorp/aws"
-            version = "~> 3.0"
-        }
-    }
-}
+# terraform {
+#     required_providers {
+#         aws = {
+#             source  = "hashicorp/aws"
+#             version = "~> 3.0"
+#         }
+#     }
+# }
 
-provider "aws" {
-    region = "eu-west-2"
-}
+# provider "aws" {
+#     region = "eu-west-2"
+# }
 
-data "aws_caller_identity" "current" {}
+# data "aws_caller_identity" "current" {}
 
-data "aws_region" "current" {}
+# data "aws_region" "current" {}
 
-locals {
-    parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
+# locals {
+#     parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+# }
 
-terraform {
-  backend "s3" {
-    bucket  = "terraform-state-staging-apis"
-    encrypt = true
-    region  = "eu-west-2"
-    key     = "services/repairs-listener/state"
-  }
-}
+# terraform {
+#   backend "s3" {
+#     bucket  = "terraform-state-staging-apis"
+#     encrypt = true
+#     region  = "eu-west-2"
+#     key     = "services/repairs-listener/state"
+#   }
+# }
 
-### TODO - Replace all instances of SOME-SOURCE-DOMAIN and THIS_DOMAIN (in lower case) with the domains required below.
+# ### TODO - Replace all instances of SOME-SOURCE-DOMAIN and THIS_DOMAIN (in lower case) with the domains required below.
 
-### This is the parameter containing the arn of the topic to which we want to subscribe
-### This will have been created by the service the generates the events in which we are interested
-#
-data "aws_ssm_parameter" "assets_sns_topic_arn" {
-   name = "/sns-topic/staging/asset/arn"
-}
+# ### This is the parameter containing the arn of the topic to which we want to subscribe
+# ### This will have been created by the service the generates the events in which we are interested
+# #
+# data "aws_ssm_parameter" "assets_sns_topic_arn" {
+#    name = "/sns-topic/staging/asset/arn"
+# }
 
-### This is the definition of the dead letter queue used whem message processsing fails for a given message
-#
-resource "aws_sqs_queue" "repairshubinbound_dead_letter_queue" {
-   name                        = "repairshubinbounddeadletterqueue.fifo"
-   fifo_queue                  = true
-   content_based_deduplication = true
-   kms_master_key_id           = "alias/housing-staging-cmk"
-   kms_data_key_reuse_period_seconds = 300
- }
+# ### This is the definition of the dead letter queue used whem message processsing fails for a given message
+# #
+# resource "aws_sqs_queue" "repairshubinbound_dead_letter_queue" {
+#    name                        = "repairshubinbounddeadletterqueue.fifo"
+#    fifo_queue                  = true
+#    content_based_deduplication = true
+#    kms_master_key_id           = "alias/housing-staging-cmk"
+#    kms_data_key_reuse_period_seconds = 300
+#  }
 
-### This is the queue  which will receive the events published to the topic listed above
-### This is what the listener lambda function will get triggered by.
+# ### This is the queue  which will receive the events published to the topic listed above
+# ### This is what the listener lambda function will get triggered by.
 
-resource "aws_sqs_queue" "repairshubinbound_queue" {
-   name                        = "repairshubinboundqueue.fifo"
-   fifo_queue                  = true
-   content_based_deduplication = true
-   kms_master_key_id           = "alias/housing-staging-cmk"           # This is a custom key
-   kms_data_key_reuse_period_seconds = 300
-   redrive_policy              = jsonencode({
-     deadLetterTargetArn = aws_sqs_queue.repairshubinbound_dead_letter_queue.arn,
-     maxReceiveCount     = 3                                               # Messages that fail processing are retried twice before being moved to the dead letter queue
-   })
-}
+# resource "aws_sqs_queue" "repairshubinbound_queue" {
+#    name                        = "repairshubinboundqueue.fifo"
+#    fifo_queue                  = true
+#    content_based_deduplication = true
+#    kms_master_key_id           = "alias/housing-staging-cmk"           # This is a custom key
+#    kms_data_key_reuse_period_seconds = 300
+#    redrive_policy              = jsonencode({
+#      deadLetterTargetArn = aws_sqs_queue.repairshubinbound_dead_letter_queue.arn,
+#      maxReceiveCount     = 3                                               # Messages that fail processing are retried twice before being moved to the dead letter queue
+#    })
+# }
 
-### This is the AWS policy that allows the topic to forward an event to the queue declared above
+# ### This is the AWS policy that allows the topic to forward an event to the queue declared above
 
-resource "aws_sqs_queue_policy" "repairshubinbound_queue_policy" {
-  queue_url = aws_sqs_queue.repairshubinbound_queue.id
-  policy = <<POLICY
-  {
-      "Version": "2012-10-17",
-      "Id": "sqspolicy",
-      "Statement": [
-      {
-          "Sid": "First",
-          "Effect": "Allow",
-          "Principal": "*",
-          "Action": "sqs:SendMessage",
-          "Resource": "${aws_sqs_queue.repairshubinbound_queue.arn}",
-          "Condition": {
-          "ArnEquals": {
-              "aws:SourceArn": "${data.aws_ssm_parameter.assets_sns_topic_arn.value}"
-          }
-          }
-      }
-      ]
-  }
-  POLICY
-}
+# resource "aws_sqs_queue_policy" "repairshubinbound_queue_policy" {
+#   queue_url = aws_sqs_queue.repairshubinbound_queue.id
+#   policy = <<POLICY
+#   {
+#       "Version": "2012-10-17",
+#       "Id": "sqspolicy",
+#       "Statement": [
+#       {
+#           "Sid": "First",
+#           "Effect": "Allow",
+#           "Principal": "*",
+#           "Action": "sqs:SendMessage",
+#           "Resource": "${aws_sqs_queue.repairshubinbound_queue.arn}",
+#           "Condition": {
+#           "ArnEquals": {
+#               "aws:SourceArn": "${data.aws_ssm_parameter.assets_sns_topic_arn.value}"
+#           }
+#           }
+#       }
+#       ]
+#   }
+#   POLICY
+# }
 
-### This is the subscription definition that tells the topic which queue to use
+# ### This is the subscription definition that tells the topic which queue to use
 
-resource "aws_sns_topic_subscription" "repairshubinbound_queue_subscribe_to_assets_sns" {
-   topic_arn = data.aws_ssm_parameter.assets_sns_topic_arn.value
-   protocol  = "sqs"
-   endpoint  = aws_sqs_queue.repairshubinbound_queue.arn
-   raw_message_delivery = true
-}
+# resource "aws_sns_topic_subscription" "repairshubinbound_queue_subscribe_to_assets_sns" {
+#    topic_arn = data.aws_ssm_parameter.assets_sns_topic_arn.value
+#    protocol  = "sqs"
+#    endpoint  = aws_sqs_queue.repairshubinbound_queue.arn
+#    raw_message_delivery = true
+# }
 
-### This creates an AWS parameter with arn of the queue that will then be used within the Serverless.yml
-### to specify the queue that will trigger the lambda function.
+# ### This creates an AWS parameter with arn of the queue that will then be used within the Serverless.yml
+# ### to specify the queue that will trigger the lambda function.
 
-resource "aws_ssm_parameter" "repairshubinbound_sqs_queue_arn" {
-  name  = "/sqs-queue/staging/repairshubinbound/arn"
-  type  = "String"
-  value = aws_sqs_queue.repairshubinbound_queue.arn
-}
+# resource "aws_ssm_parameter" "repairshubinbound_sqs_queue_arn" {
+#   name  = "/sqs-queue/staging/repairshubinbound/arn"
+#   type  = "String"
+#   value = aws_sqs_queue.repairshubinbound_queue.arn
+# }
 


### PR DESCRIPTION
## Summary of Changes

The pipeline was failing to deploy to staging. From what I can gather, this was attempted before, but was not successful. Repairs API sits within the staging-apis account, but the asset topic sits within the housing staging account. So I think this created difficulties getting this listener to work within that environment.

I don't expect this listener to be updated any time soon, so fixing this deployment is out of scope (DOTNET 8 upgrade).

For that reason, I have disabled the deployment for staging.

Additionally, I have updated the pipeline and added terraform plan jobs.

